### PR TITLE
Fix Energy Management Build

### DIFF
--- a/examples/energy-management-app/silabs/BUILD.gn
+++ b/examples/energy-management-app/silabs/BUILD.gn
@@ -137,15 +137,16 @@ silabs_executable("energy-management-app") {
 
   sources = [
     "${examples_common_plat_dir}/main.cpp",
-    "../energy-management-common/src/DeviceEnergyManagementDelegateImpl.cpp",
-    "../energy-management-common/src/DeviceEnergyManagementManager.cpp",
-    "../energy-management-common/src/EVSEManufacturerImpl.cpp",
-    "../energy-management-common/src/ElectricalPowerMeasurementDelegate.cpp",
-    "../energy-management-common/src/EnergyEvseDelegateImpl.cpp",
-    "../energy-management-common/src/EnergyEvseMain.cpp",
-    "../energy-management-common/src/EnergyEvseManager.cpp",
-    "../energy-management-common/src/device-energy-management-mode.cpp",
-    "../energy-management-common/src/energy-evse-mode.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/DeviceEnergyManagementDelegateImpl.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/DeviceEnergyManagementManager.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/EVSEManufacturerImpl.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/ElectricalPowerMeasurementDelegate.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/EnergyEvseDelegateImpl.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/EnergyEvseMain.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/EnergyEvseManager.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/PowerTopologyDelegate.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/device-energy-management-mode.cpp",
+    "${chip_root}/examples/energy-management-app/energy-management-common/src/energy-evse-mode.cpp",
     "src/AppTask.cpp",
   ]
 

--- a/examples/energy-management-app/silabs/build_for_wifi_args.gni
+++ b/examples/energy-management-app/silabs/build_for_wifi_args.gni
@@ -18,6 +18,6 @@ silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/wifi_args.gni")
 
-chip_enable_ota_requestor = true
+chip_enable_ota_requestor = false
 app_data_model =
     "${chip_root}/examples/energy-management-app/energy-management-common"

--- a/examples/energy-management-app/silabs/openthread.gni
+++ b/examples/energy-management-app/silabs/openthread.gni
@@ -20,7 +20,7 @@ silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 app_data_model =
     "${chip_root}/examples/energy-management-app/energy-management-common"
-chip_enable_ota_requestor = true
+chip_enable_ota_requestor = false
 chip_enable_openthread = true
 
 openthread_external_platform =


### PR DESCRIPTION
Removed the OTA requestor source files, if we want to add them back, we need to also add the OTA requestor cluster


